### PR TITLE
fixed value reference

### DIFF
--- a/templates/jobs/promote-deployment.yaml
+++ b/templates/jobs/promote-deployment.yaml
@@ -13,7 +13,7 @@ stages:
       variables:
         - group: 'sitecore-xm-cloud-variables'
         - name: deploymentId
-          value: $[stageDependencies.create_deployment_on_dev.create_deployment_on_dev_job.outputs['create_deployment_on_dev_job.CreateDeployment.deploymentId']]
+          value: $[stageDependencies.create_deployment_on_test.create_deployment_on_test_job.outputs[create_deployment_on_test_job.CreateDeployment.deploymentId']]
       pool:
         vmImage: windows-latest
       environment: ${{ parameters.env }}


### PR DESCRIPTION
The value reference points to a dev instance rather than a test instance as named in your pipeline.yaml file. I've fixed the issue in the promote-deployment.yaml template.